### PR TITLE
Adds the command option to the pcf-tile manifest

### DIFF
--- a/pcf-tile/tile.yml
+++ b/pcf-tile/tile.yml
@@ -30,6 +30,7 @@ packages:
   manifest:
     path: resources/azure-log-analytics-nozzle.zip
     buildpack: go_buildpack
+    command: oms-log-analytics-firehose-nozzle
     instances: (( .properties.nozzle_instance_number.value ))
     memory: 512M
     no-route: true


### PR DESCRIPTION
go_buildpack version: cflinuxfs2-v1.8.33
tile version: 1.3.0

Deploying the tile to our environment causes the following error in PCF:
```
[APP/PROC/WEB] bash: ./bin/...  No such file or directory
```

Fix:
1. Rerun the errand and keep the VM alive: `bosh -d $LOG_ANALYTICS_GUID run-errand deploy-all --keep-alive`
2. SSH into the VM: `bosh -d $LOG_ANALYTICS_GUID ssh deploy-all`
3. Modify the `/var/vcap/jobs/deploy-all/bin/run` script by adding to the escaped yaml: `\"command\": \"oms-log-analytics-firehose-nozzle\",` as seen [here](https://github.com/Azure/oms-log-analytics-firehose-nozzle/blob/master/manifest.yml#L7)
4. Rerun the errand by hand as `vcap`: `/var/vcap/jobs/deploy-all/bin/run`